### PR TITLE
[SC-37908] Customized user agent string

### DIFF
--- a/aptibleapi/configuration.go
+++ b/aptibleapi/configuration.go
@@ -89,7 +89,7 @@ type APIConfiguration struct {
 func NewAPIConfiguration() *APIConfiguration {
 	cfg := &APIConfiguration{
 		DefaultHeader:    make(map[string]string),
-		UserAgent:        aptibleClientVersion(),
+		UserAgent:        "aptible/aptible-api-go/" + aptibleClientVersion(),
 		Debug:            false,
 		Servers:          ServerConfigurations{
 			{

--- a/aptibleapi/configuration.go
+++ b/aptibleapi/configuration.go
@@ -89,7 +89,7 @@ type APIConfiguration struct {
 func NewAPIConfiguration() *APIConfiguration {
 	cfg := &APIConfiguration{
 		DefaultHeader:    make(map[string]string),
-		UserAgent:        "OpenAPI-Generator/1.0.0/go",
+		UserAgent:        aptibleClientVersion(),
 		Debug:            false,
 		Servers:          ServerConfigurations{
 			{

--- a/aptibleapi/version.go
+++ b/aptibleapi/version.go
@@ -1,0 +1,14 @@
+package aptibleapi
+
+import "runtime/debug"
+
+func aptibleClientVersion() string {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, dep := range info.Deps {
+			if dep.Path == "github.com/aptible/aptible-api-go" {
+				return "aptible/aptible-api-go/" + dep.Version
+			}
+		}
+	}
+	return "aptible/aptible-api-go/unknown"
+}

--- a/aptibleapi/version.go
+++ b/aptibleapi/version.go
@@ -9,6 +9,9 @@ func aptibleClientVersion() string {
 				return "aptible/aptible-api-go/" + dep.Version
 			}
 		}
+		if info.Main.Version != "" {
+			return "aptible/aptible-api-go/" + info.Main.Version
+		}
 	}
 	return "aptible/aptible-api-go/unknown"
 }

--- a/aptibleapi/version.go
+++ b/aptibleapi/version.go
@@ -6,12 +6,12 @@ func aptibleClientVersion() string {
 	if info, ok := debug.ReadBuildInfo(); ok {
 		for _, dep := range info.Deps {
 			if dep.Path == "github.com/aptible/aptible-api-go" {
-				return "aptible/aptible-api-go/" + dep.Version
+				return dep.Version
 			}
 		}
-		if info.Main.Version != "" {
-			return "aptible/aptible-api-go/" + info.Main.Version
+		if info.Main.Path == "github.com/aptible/aptible-api-go" {
+			return info.Main.Version
 		}
 	}
-	return "aptible/aptible-api-go/unknown"
+	return "unknown"
 }

--- a/aptibleapi/version_test.go
+++ b/aptibleapi/version_test.go
@@ -4,7 +4,15 @@ import "testing"
 
 func TestAptibleClientVersion(t *testing.T) {
 	v := aptibleClientVersion()
-	if v == "aptible/aptible-api-go/unknown" {
+	if v == "unknown" {
 		t.Errorf("aptibleClientVersion() returned %q", v)
+	}
+}
+
+func TestUserAgent(t *testing.T) {
+	cfg := NewAPIConfiguration()
+	expected := "aptible/aptible-api-go/" + aptibleClientVersion()
+	if cfg.UserAgent != expected {
+		t.Errorf("UserAgent = %q, want %q", cfg.UserAgent, expected)
 	}
 }

--- a/aptibleapi/version_test.go
+++ b/aptibleapi/version_test.go
@@ -1,0 +1,10 @@
+package aptibleapi
+
+import "testing"
+
+func TestAptibleClientVersion(t *testing.T) {
+	v := aptibleClientVersion()
+	if v == "aptible/aptible-api-go/unknown" {
+		t.Errorf("aptibleClientVersion() returned %q", v)
+	}
+}

--- a/templates/configuration.mustache
+++ b/templates/configuration.mustache
@@ -135,7 +135,7 @@ type APIConfiguration struct {
 func NewAPIConfiguration() *APIConfiguration {
 	cfg := &APIConfiguration{
 		DefaultHeader:    make(map[string]string),
-		UserAgent:        "{{{httpUserAgent}}}{{^httpUserAgent}}OpenAPI-Generator/{{{packageVersion}}}/go{{/httpUserAgent}}",
+		UserAgent:        aptibleClientVersion(),
 		Debug:            false,
 		{{#servers}}
 		{{#-first}}

--- a/templates/configuration.mustache
+++ b/templates/configuration.mustache
@@ -135,7 +135,7 @@ type APIConfiguration struct {
 func NewAPIConfiguration() *APIConfiguration {
 	cfg := &APIConfiguration{
 		DefaultHeader:    make(map[string]string),
-		UserAgent:        aptibleClientVersion(),
+		UserAgent:        "aptible/aptible-api-go/" + aptibleClientVersion(),
 		Debug:            false,
 		{{#servers}}
 		{{#-first}}


### PR DESCRIPTION
This customizes the mustache template's user-agent string to intentionally set the user agent of this client to a custom value, much like https://github.com/aptible/go-deploy/pull/73